### PR TITLE
Add correct release label to manifest

### DIFF
--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -18,7 +18,7 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -39,7 +39,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
 
@@ -77,7 +77,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -92,7 +92,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -107,7 +107,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
@@ -132,7 +132,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     serving.knative.dev/controller: "true"
 rules:
   - apiGroups: [""]
@@ -182,7 +182,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
 
@@ -218,14 +218,14 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -237,7 +237,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -317,7 +317,7 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -372,7 +372,7 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -436,7 +436,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -492,7 +492,7 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -545,7 +545,7 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -607,7 +607,7 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -672,7 +672,7 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -732,7 +732,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -799,7 +799,7 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -930,7 +930,7 @@ metadata:
   name: queue-proxy
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -956,7 +956,7 @@ metadata:
   name: config-autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "604cb513"
 data:
@@ -1160,7 +1160,7 @@ metadata:
   name: config-defaults
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "cdabec96"
 data:
@@ -1293,7 +1293,7 @@ metadata:
   name: config-deployment
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "fa67b403"
 data:
@@ -1373,7 +1373,7 @@ metadata:
   name: config-domain
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "74c3fc6a"
 data:
@@ -1435,7 +1435,7 @@ metadata:
   name: config-features
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "2cf73688"
 data:
@@ -1570,7 +1570,7 @@ metadata:
   name: config-gc
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "e6149382"
 data:
@@ -1667,7 +1667,7 @@ metadata:
   name: config-leader-election
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "96896b00"
 data:
@@ -1726,7 +1726,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "d9570453"
 data:
@@ -1803,7 +1803,7 @@ metadata:
   name: config-network
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "15954d34"
 data:
@@ -1935,7 +1935,7 @@ metadata:
   name: config-observability
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "97c1d10b"
 data:
@@ -2054,7 +2054,7 @@ metadata:
   name: config-tracing
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "4002b4c2"
 data:
@@ -2113,7 +2113,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -2139,7 +2139,7 @@ metadata:
   name: activator-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minAvailable: 80%
   selector:
@@ -2166,7 +2166,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -2179,7 +2179,7 @@ spec:
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       serviceAccountName: controller
       containers:
@@ -2273,7 +2273,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: activator
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     app: activator
@@ -2313,7 +2313,7 @@ metadata:
   name: autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   replicas: 1
   selector:
@@ -2325,7 +2325,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -2410,7 +2410,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -2448,7 +2448,7 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -2459,7 +2459,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -2525,7 +2525,7 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -2560,7 +2560,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -2584,7 +2584,7 @@ metadata:
   name: webhook-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minAvailable: 80%
   selector:
@@ -2611,7 +2611,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -2624,7 +2624,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -2713,7 +2713,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: webhook
   namespace: knative-serving
 spec:
@@ -2750,7 +2750,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -2785,7 +2785,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -2816,7 +2816,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -2848,7 +2848,7 @@ metadata:
   name: webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -2870,7 +2870,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2918,7 +2918,7 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2978,7 +2978,7 @@ metadata:
   name: domain-mapping
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -2989,7 +2989,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -3064,7 +3064,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -3096,7 +3096,7 @@ metadata:
   name: domainmapping-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -3118,7 +3118,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -3150,7 +3150,7 @@ metadata:
   name: domainmapping-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -3163,7 +3163,7 @@ spec:
       labels:
         app: domainmapping-webhook
         role: domainmapping-webhook
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -3250,7 +3250,7 @@ kind: Service
 metadata:
   labels:
     role: domainmapping-webhook
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -3288,7 +3288,7 @@ metadata:
   name: autoscaler-hpa
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
 spec:
   selector:
@@ -3300,7 +3300,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: autoscaler-hpa
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -3362,7 +3362,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler-hpa
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
   name: autoscaler-hpa
   namespace: knative-serving

--- a/openshift/release/knative-serving-v0.22.0.yaml
+++ b/openshift/release/knative-serving-v0.22.0.yaml
@@ -18,7 +18,7 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -39,7 +39,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
 
@@ -77,7 +77,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -92,7 +92,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -107,7 +107,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
@@ -132,7 +132,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     serving.knative.dev/controller: "true"
 rules:
   - apiGroups: [""]
@@ -182,7 +182,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
 
@@ -218,14 +218,14 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -237,7 +237,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -317,7 +317,7 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -372,7 +372,7 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -436,7 +436,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -492,7 +492,7 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -545,7 +545,7 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -607,7 +607,7 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -672,7 +672,7 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -732,7 +732,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -799,7 +799,7 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -930,7 +930,7 @@ metadata:
   name: queue-proxy
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -956,7 +956,7 @@ metadata:
   name: config-autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "604cb513"
 data:
@@ -1160,7 +1160,7 @@ metadata:
   name: config-defaults
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "cdabec96"
 data:
@@ -1293,7 +1293,7 @@ metadata:
   name: config-deployment
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "fa67b403"
 data:
@@ -1373,7 +1373,7 @@ metadata:
   name: config-domain
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "74c3fc6a"
 data:
@@ -1435,7 +1435,7 @@ metadata:
   name: config-features
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "2cf73688"
 data:
@@ -1570,7 +1570,7 @@ metadata:
   name: config-gc
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "e6149382"
 data:
@@ -1667,7 +1667,7 @@ metadata:
   name: config-leader-election
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "96896b00"
 data:
@@ -1726,7 +1726,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "d9570453"
 data:
@@ -1803,7 +1803,7 @@ metadata:
   name: config-network
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "15954d34"
 data:
@@ -1935,7 +1935,7 @@ metadata:
   name: config-observability
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "97c1d10b"
 data:
@@ -2054,7 +2054,7 @@ metadata:
   name: config-tracing
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "4002b4c2"
 data:
@@ -2113,7 +2113,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -2139,7 +2139,7 @@ metadata:
   name: activator-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minAvailable: 80%
   selector:
@@ -2166,7 +2166,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -2179,7 +2179,7 @@ spec:
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       serviceAccountName: controller
       containers:
@@ -2273,7 +2273,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: activator
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     app: activator
@@ -2313,7 +2313,7 @@ metadata:
   name: autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   replicas: 1
   selector:
@@ -2325,7 +2325,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -2410,7 +2410,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -2448,7 +2448,7 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -2459,7 +2459,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -2525,7 +2525,7 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -2560,7 +2560,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -2584,7 +2584,7 @@ metadata:
   name: webhook-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minAvailable: 80%
   selector:
@@ -2611,7 +2611,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -2624,7 +2624,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -2713,7 +2713,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: webhook
   namespace: knative-serving
 spec:
@@ -2750,7 +2750,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -2785,7 +2785,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -2816,7 +2816,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -2848,7 +2848,7 @@ metadata:
   name: webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -2870,7 +2870,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2918,7 +2918,7 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2978,7 +2978,7 @@ metadata:
   name: domain-mapping
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -2989,7 +2989,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -3064,7 +3064,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -3096,7 +3096,7 @@ metadata:
   name: domainmapping-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -3118,7 +3118,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -3150,7 +3150,7 @@ metadata:
   name: domainmapping-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -3163,7 +3163,7 @@ spec:
       labels:
         app: domainmapping-webhook
         role: domainmapping-webhook
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -3250,7 +3250,7 @@ kind: Service
 metadata:
   labels:
     role: domainmapping-webhook
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -3288,7 +3288,7 @@ metadata:
   name: autoscaler-hpa
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
 spec:
   selector:
@@ -3300,7 +3300,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: autoscaler-hpa
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -3362,7 +3362,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler-hpa
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
   name: autoscaler-hpa
   namespace: knative-serving

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -26,6 +26,6 @@ function resolve_file() {
   # 1. Rewrite image references
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
-  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.21.0\"+" \
+  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.22.0\"+" \
       "$file" >> "$to"
 }


### PR DESCRIPTION
This patch adds correct release label with `v0.22.0` in manifest.